### PR TITLE
Fix e4mc + Krypton conflict by conditionally disabling encryption mixin

### DIFF
--- a/common/src/main/java/link/e4mc/mixin/E4mcMixinPlugin.java
+++ b/common/src/main/java/link/e4mc/mixin/E4mcMixinPlugin.java
@@ -1,0 +1,52 @@
+package link.e4mc.mixin;
+
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class E4mcMixinPlugin implements IMixinConfigPlugin {
+    private static final boolean KRYPTON_LOADED = isKryptonLoaded();
+
+    @Override
+    public void onLoad(String mixinPackage) {}
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // Disable ServerLoginPacketListenerImplMixin if Krypton is loaded
+        // Krypton's cipher optimization takes priority
+        if (mixinClassName.contains("ServerLoginPacketListenerImplMixin") && KRYPTON_LOADED) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, org.objectweb.asm.tree.ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    private static boolean isKryptonLoaded() {
+        try {
+            Class.forName("me.steinborn.krypton.mod.shared.KryptonMixinPlugin");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/common/src/main/resources/e4mc.mixins.json
+++ b/common/src/main/resources/e4mc.mixins.json
@@ -3,6 +3,7 @@
   "package": "link.e4mc.mixin",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
+  "plugin": "link.e4mc.mixin.E4mcMixinPlugin",
   "mixins": [
     "BanListCommandsMixin",
     "BanPlayerCommandsMixin",


### PR DESCRIPTION
Create an e4mc Mixin plugin that:
1. Detects if Krypton is loaded at runtime
2. If Krypton is present, disables `ServerLoginPacketListenerImplMixin`
3. Allows Krypton's optimized cipher to take full control
4. e4mc remains functional through its other encryption redirects 
   (`getSecretKey`, `digestData`) that handle Dialtone connections

I tested it on Minecraft 1.21.11 Fabric with krypton and e4mc only, It worked great and had no issues
as is said, Krypton doesn't seem to be actively developed, so this is the faster solution.
Fixes #215 