### PR TITLE
Fix dedicated server crash when client connects (1.21.11+)

### DIFF
--- a/common/src/main/java/link/e4mc/E4mcClient.java
+++ b/common/src/main/java/link/e4mc/E4mcClient.java
@@ -41,7 +41,7 @@ public class E4mcClient {
                                 return false;
                             }
                             if (src.getServer().isDedicatedServer()) {
-                                return src.hasPermission(4);
+                                return Mirror.hasOwnerPermission(src);
                             } else {
                                 try {
                                     return Mirror.isSingleplayerOwner(src.getServer(), src.getPlayerOrException());

--- a/common/src/main/java/link/e4mc/Mirror.java
+++ b/common/src/main/java/link/e4mc/Mirror.java
@@ -3,6 +3,7 @@ package link.e4mc;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.ChatComponent;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
@@ -14,6 +15,7 @@ import net.minecraft.server.players.PlayerList;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -303,5 +305,26 @@ public class Mirror {
                 }
             }
         });
+    }
+
+    public static boolean hasOwnerPermission(CommandSourceStack src) {
+        try {
+            return src.hasPermission(4);
+        } catch (NoSuchMethodError ex) {
+            // 1.21.11 or later
+            try {
+                // Equivalent call is `Commands.hasPermission(Commands.LEVEL_OWNERS).test(src)`
+                Class<Commands> clazz = Commands.class;
+                Object levelOwners = clazz.getField("LEVEL_OWNERS").get(null);
+                Class<?> levelOwnersType = clazz.getField("LEVEL_OWNERS").getType();
+                Method hasPermissionMethod = clazz.getMethod("hasPermission", levelOwnersType);
+                Predicate<CommandSourceStack> hasPermission = (Predicate<CommandSourceStack>) hasPermissionMethod.invoke(null, levelOwners);
+                return hasPermission.test(src);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | NoSuchFieldException unhandled) {
+                E4mcClient.LOGGER.error("Failed to check permission level!");
+                E4mcClient.LOGGER.error(unhandled.toString());
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/vgskye/e4mc-minecraft-architectury/issues/228.

In 1.21.11, `CommandSourceStack.hasPermission()` (in fact, everything from `PermissionSource`) was removed in favor of access through `Commands`. Permission levels also utilize a more structured system: https://docs.neoforged.net/primer/docs/1.21.11/#permission-overhaul

This fix handles the case where the `hasPermission()` method used previously is missing (when version is 1.21.11 or later.) There are no additional user-facing changes as a result of this fix. Clients using version 6.2.1 of the mod should still be able to connect to servers on this version.

The following vanilla (aside from the mod itself and Fabric API) setups worked as expected for me:
- Fabric 26.2 client connecting to Fabric 26.2 server
- Fabric 26.2 client (on e4mc 6.2.0) connecting to Fabric 26.2 server
- Fabric 26.2 client running integrated server
- NeoForge 26.2 client connecting to NeoForge 26.2 server
- NeoForge 26.2 client running integrated server
- Fabric 1.21.10 client connecting to Fabric 1.21.10 server
- Fabric 1.21.10 client running integrated server
- Forge 1.20.1 client connecting to Forge 1.20.1 server
- Forge 1.20.1 client running integrated server