### PR TITLE
Refactor ServerLoginPacketListenerImplMixin to use WrapOperation

### DIFF
--- a/common/src/main/java/link/e4mc/mixin/ServerLoginPacketListenerImplMixin.java
+++ b/common/src/main/java/link/e4mc/mixin/ServerLoginPacketListenerImplMixin.java
@@ -1,18 +1,17 @@
 package link.e4mc.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import link.e4mc.DialtoneConnectionExtensions;
 import link.e4mc.dialtone.DialtoneAddress;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.login.ServerboundKeyPacket;
 import net.minecraft.server.network.ServerLoginPacketListenerImpl;
-import net.minecraft.util.Crypt;
-import net.minecraft.util.CryptException;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -20,35 +19,34 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.Arrays;
 
 @Mixin(ServerLoginPacketListenerImpl.class)
 public class ServerLoginPacketListenerImplMixin {
     @Shadow @Final
     Connection connection;
 
-    @Redirect(method = "handleHello", at = @At(value = "INVOKE", target = "Ljava/security/PublicKey;getEncoded()[B"))
-    private byte[] killDoubleEncryption(PublicKey instance) {
+    @WrapOperation(method = "handleHello", at = @At(value = "INVOKE", target = "Ljava/security/PublicKey;getEncoded()[B"))
+    private byte[] killDoubleEncryption(PublicKey instance, Operation<byte[]> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return new byte[0];
         }
-        return instance.getEncoded();
+        return operation.call(instance);
     }
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "*([BLjava/security/PrivateKey;)Z", remap = false), require = 0)
-    private boolean isChallengeValid(ServerboundKeyPacket instance, byte[] bs, PrivateKey privateKey) {
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "*([BLjava/security/PrivateKey;)Z", remap = false), require = 0)
+    private boolean isChallengeValid(ServerboundKeyPacket instance, byte[] bs, PrivateKey privateKey, Operation<Boolean> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return true;
         }
-        return instance.isChallengeValid(bs, privateKey);
+        return operation.call(instance, bs, privateKey);
     }
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Ljava/util/Arrays;equals([B[B)Z"), require = 0)
-    private boolean isNonceEqual(byte[] lhs, byte[] rhs) {
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "Ljava/util/Arrays;equals([B[B)Z"), require = 0)
+    private boolean isNonceEqual(byte[] lhs, byte[] rhs, Operation<Boolean> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return true;
         }
-        return Arrays.equals(lhs, rhs);
+        return operation.call(lhs, rhs);
     }
 
     @ModifyArg(method = "handleKey", at = @At(value = "INVOKE", target = "*(Ljava/security/PrivateKey;)[B", remap = false), index = 0, require = 0)
@@ -59,27 +57,27 @@ public class ServerLoginPacketListenerImplMixin {
         return privateKey;
     }
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/login/ServerboundKeyPacket;getSecretKey(Ljava/security/PrivateKey;)Ljavax/crypto/SecretKey;"))
-    private SecretKey getSecretKey(ServerboundKeyPacket instance, PrivateKey privateKey) throws CryptException {
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/login/ServerboundKeyPacket;getSecretKey(Ljava/security/PrivateKey;)Ljavax/crypto/SecretKey;"))
+    private SecretKey getSecretKey(ServerboundKeyPacket instance, PrivateKey privateKey, Operation<SecretKey> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return null;
         }
-        return instance.getSecretKey(privateKey);
+        return operation.call(instance, privateKey);
     }
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Crypt;getCipher(ILjava/security/Key;)Ljavax/crypto/Cipher;"))
-    private Cipher getCipher(int i, Key key) throws CryptException {
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Crypt;getCipher(ILjava/security/Key;)Ljavax/crypto/Cipher;"))
+    private Cipher getCipher(int i, Key key, Operation<Cipher> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return null;
         }
-        return Crypt.getCipher(i, key);
+        return operation.call(i, key);
     }
 
-    @Redirect(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Crypt;digestData(Ljava/lang/String;Ljava/security/PublicKey;Ljavax/crypto/SecretKey;)[B"))
-    private byte[] digestData(String string, PublicKey publicKey, SecretKey secretKey) throws CryptException {
+    @WrapOperation(method = "handleKey", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Crypt;digestData(Ljava/lang/String;Ljava/security/PublicKey;Ljavax/crypto/SecretKey;)[B"))
+    private byte[] digestData(String string, PublicKey publicKey, SecretKey secretKey, Operation<byte[]> operation) {
         if (connection.getRemoteAddress() instanceof DialtoneAddress) {
             return ((DialtoneConnectionExtensions) connection).e4mc$exportKeyingMaterial("EXPERIMENTAL mojang authentication".getBytes(StandardCharsets.UTF_8), new byte[0], 20);
         }
-        return Crypt.digestData(string, publicKey, secretKey);
+        return operation.call(string, publicKey, secretKey);
     }
 }


### PR DESCRIPTION
Hey again

This PR replaces the `@Redirect`  in `ServerLoginPacketListenerImplMixin` with MixinExtras `@WrapOperation` to resolve mixin collisions on `handleKey` 

- Replaced the 6 `@Redirect`s in `ServerLoginPacketListenerImplMixin` with `@WrapOperation`.

- Dialtone connection bypass behavior is completely unchanged, and regular connections just pass through normally without breaking other mods.

Fixes compatibility crashes when running alongside Krypton and other networking mixins. Tested and verified and it works.

fixes #215 